### PR TITLE
feat: crear clase VehiculoPrinter y extraer lógica de impresión desde Main

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -5,39 +5,53 @@ public class Main {
 
     /**
      * Método principal que ejecuta el programa.
-     * Crea instancias de Vehiculo e imprime su información por consola.
+     * Crea instancias de Vehiculo e imprime su información por consola
+     * utilizando la clase VehiculoPrinter.
      *
      * @param args Argumentos de línea de comandos (no utilizados en este programa)
      */
+
     public static void main(String[] args) {
+        VehiculoPrinter printer = new VehiculoPrinter();
+
         Vehiculo v1 = new Vehiculo("ABC123", "Toyota", 2015, 1200.0);
         Vehiculo v2 = new Vehiculo("DEF456", "Ford", 2020, 1500.0);
         Vehiculo v3 = new Vehiculo("GHI789", "Honda", 2018, 1000.0);
 
-        v1.mostrarInformacion();
+        // v1.mostrarInformacion();
+        // System.out.println();
+        // v2.mostrarInformacion();
+        // System.out.println();
+        // v3.mostrarInformacion();
+
+        printer.imprimirInformacion(v1);
         System.out.println();
-        v2.mostrarInformacion();
+        printer.imprimirInformacion(v2);
         System.out.println();
-        v3.mostrarInformacion();
+        printer.imprimirInformacion(v3);
+
 
         // Intentar crear un vehículo con año inválido
         try {
             Vehiculo v4 = new Vehiculo("JKL999", "Chevrolet", 1800, 1300.0);
-            v4.mostrarInformacion();
+            // v4.mostrarInformacion();
+            printer.imprimirInformacion(v4);
         } catch (IllegalArgumentException e) {
             System.out.println("\nError al crear vehículo inválido: " + e.getMessage());
         }
         // Intentar crear un vehículo con patente vacía
         try {
             Vehiculo v5 = new Vehiculo("", "Nissan", 2019, 1100.0);
-            v5.mostrarInformacion();
+            // v5.mostrarInformacion();
+            printer.imprimirInformacion(v5);
         } catch (IllegalArgumentException e) {
             System.out.println("\nError al crear vehículo con patente vacía: " + e.getMessage());
         }
         // Intentar crear un vehículo con capacidad de carga negativa
         try {
             Vehiculo v6 = new Vehiculo("MNO321", "Volkswagen", 2017, -500.0);
-            v6.mostrarInformacion();
+            // v6.mostrarInformacion();
+            printer.imprimirInformacion(v6);
         } catch (IllegalArgumentException e) {
             System.out.println("\nError al crear vehículo con carga negativa: " + e.getMessage());
         }

--- a/src/VehiculoPrinter.java
+++ b/src/VehiculoPrinter.java
@@ -1,0 +1,27 @@
+/**
+ * Clase encargada de imprimir por consola la información de un objeto Vehiculo.
+ * Aplica el principio de responsabilidad única (SRP), separando la lógica de presentación
+ * del modelo de datos.
+ */
+public class VehiculoPrinter {
+
+    /**
+     * Imprime por consola los datos del vehículo proporcionado.
+     * Si el parámetro es null, se muestra un mensaje de error.
+     *
+     * @param vehiculo El objeto Vehiculo cuya información se desea mostrar.
+     */
+    public void imprimirInformacion(Vehiculo vehiculo) {
+        if (vehiculo == null) {
+            System.out.println("Error: El vehículo proporcionado es null.");
+            return;
+        }
+
+        System.out.println("=== Información del Vehículo ===");
+        System.out.println("Patente: " + vehiculo.getPatente());
+        System.out.println("Marca: " + vehiculo.getMarca());
+        System.out.println("Año: " + vehiculo.getAnio());
+        System.out.println("Capacidad de carga (kg): " + vehiculo.getCapacidadCargaKg());
+        System.out.println("===============================");
+    }
+}


### PR DESCRIPTION
Closes #5 

Se implementa la clase `VehiculoPrinter` que:

- Aplica el principio de responsabilidad única (SRP) al separar la lógica de presentación del modelo `Vehiculo`.
- Contiene el método público `imprimirInformacion(Vehiculo vehiculo)` que:
    - Imprime los datos del vehículo en un formato legible.
    - Maneja correctamente el caso en que el objeto recibido sea `null`.

Se actualizó la clase `Main` para:

- Crear una instancia de `VehiculoPrinter`.
- Utilizar el nuevo método `imprimirInformacion()` para mostrar la información de los vehículos válidos e inválidos.
- Comentar las llamadas anteriores a `mostrarInformacion()` en espera de su eliminación futura.

Se agregó documentación JavaDoc básica en ambas clases (`VehiculoPrinter` y `Main`).
