### PR TITLE
refactor: aplicar SRP eliminando mostrarInformacion() de Vehiculo

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -18,12 +18,6 @@ public class Main {
         Vehiculo v2 = new Vehiculo("DEF456", "Ford", 2020, 1500.0);
         Vehiculo v3 = new Vehiculo("GHI789", "Honda", 2018, 1000.0);
 
-        // v1.mostrarInformacion();
-        // System.out.println();
-        // v2.mostrarInformacion();
-        // System.out.println();
-        // v3.mostrarInformacion();
-
         printer.imprimirInformacion(v1);
         System.out.println();
         printer.imprimirInformacion(v2);
@@ -34,7 +28,6 @@ public class Main {
         // Intentar crear un vehículo con año inválido
         try {
             Vehiculo v4 = new Vehiculo("JKL999", "Chevrolet", 1800, 1300.0);
-            // v4.mostrarInformacion();
             printer.imprimirInformacion(v4);
         } catch (IllegalArgumentException e) {
             System.out.println("\nError al crear vehículo inválido: " + e.getMessage());
@@ -42,7 +35,6 @@ public class Main {
         // Intentar crear un vehículo con patente vacía
         try {
             Vehiculo v5 = new Vehiculo("", "Nissan", 2019, 1100.0);
-            // v5.mostrarInformacion();
             printer.imprimirInformacion(v5);
         } catch (IllegalArgumentException e) {
             System.out.println("\nError al crear vehículo con patente vacía: " + e.getMessage());
@@ -50,7 +42,6 @@ public class Main {
         // Intentar crear un vehículo con capacidad de carga negativa
         try {
             Vehiculo v6 = new Vehiculo("MNO321", "Volkswagen", 2017, -500.0);
-            // v6.mostrarInformacion();
             printer.imprimirInformacion(v6);
         } catch (IllegalArgumentException e) {
             System.out.println("\nError al crear vehículo con carga negativa: " + e.getMessage());

--- a/src/Vehiculo.java
+++ b/src/Vehiculo.java
@@ -33,19 +33,6 @@ public class Vehiculo {
     }
 
     /**
-     * Muestra por consola toda la información del vehículo con un formato legible,
-     * incluyendo la patente, marca, año y capacidad de carga.
-     */
-    public void mostrarInformacion() {
-        System.out.println("=== Información del Vehículo ===");
-        System.out.println("Patente: " + getPatente());
-        System.out.println("Marca: " + getMarca());
-        System.out.println("Año: " + getAnio());
-        System.out.println("Capacidad de carga (kg): " + getCapacidadCargaKg());
-        System.out.println("===============================");
-    }
-
-    /**
      * Obtiene la patente del vehículo.
      *
      * @return La patente del vehículo.


### PR DESCRIPTION
Closes #6 

Se eliminó el método `mostrarInformacion()` de la clase `Vehiculo` y se trasladó la responsabilidad de impresión a la clase `VehiculoPrinter`, aplicando correctamente el principio de responsabilidad única (SRP).

Cambios realizados:

- Se eliminó completamente el método `mostrarInformacion()` de la clase `Vehiculo`.
- Se eliminaron todas las llamadas a `mostrarInformacion()` en el código.
- Se utilizó exclusivamente la clase `VehiculoPrinter` para mostrar información de los vehículos.
- La clase `Vehiculo` ahora contiene únicamente lógica relacionada con los datos y sus validaciones.
- Se mantuvo y complementó la documentación JavaDoc en las clases `Vehiculo`, `VehiculoPrinter` y `Main`.

Con estos cambios se refuerza la separación de responsabilidades y se facilita el mantenimiento del código en futuras extensiones.
