### PR TITLE
feat: aplicar OCP creando subclase Camion con atributo tieneAcoplado

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/Camion.java
+++ b/src/Camion.java
@@ -1,0 +1,39 @@
+/**
+ * Representa un camión, que es un tipo de vehículo con una característica adicional:
+ * puede tener un acoplado o no. Hereda de la clase Vehiculo.
+ */
+public class Camion extends Vehiculo {
+    private boolean tieneAcoplado;
+
+    /**
+     * Crea un nuevo camión con los datos especificados.
+     *
+     * @param patente Patente del camión.
+     * @param marca Marca del camión.
+     * @param anio Año de fabricación del camión.
+     * @param capacidadCargaKg Capacidad de carga del camión en kilogramos.
+     * @param tieneAcoplado Indica si el camión tiene acoplado.
+     */
+    public Camion(String patente, String marca, int anio, double capacidadCargaKg, boolean tieneAcoplado) {
+        super(patente, marca, anio, capacidadCargaKg);
+        this.tieneAcoplado = tieneAcoplado;
+    }
+
+    /**
+     * Indica si el camión tiene acoplado.
+     *
+     * @return true si tiene acoplado, false en caso contrario.
+     */
+    public boolean tieneAcoplado() {
+        return tieneAcoplado;
+    }
+
+    /**
+     * Establece si el camión tiene acoplado.
+     *
+     * @param tieneAcoplado true si tiene acoplado, false en caso contrario.
+     */
+    public void setTieneAcoplado(boolean tieneAcoplado) {
+        this.tieneAcoplado = tieneAcoplado;
+    }
+}

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,12 +1,13 @@
 /**
- * Clase principal del programa. Se encarga de crear e imprimir vehículos.
+ * Clase principal del programa. Se encarga de crear e imprimir vehículos y camiones.
  */
 public class Main {
 
     /**
      * Método principal que ejecuta el programa.
-     * Crea instancias de Vehiculo e imprime su información por consola
-     * utilizando la clase VehiculoPrinter.
+     * Crea instancias de Vehiculo y Camion, imprime su información por consola
+     * utilizando la clase VehiculoPrinter, y realiza pruebas con datos inválidos
+     * para validar el manejo de excepciones.
      *
      * @param args Argumentos de línea de comandos (no utilizados en este programa)
      */
@@ -46,5 +47,11 @@ public class Main {
         } catch (IllegalArgumentException e) {
             System.out.println("\nError al crear vehículo con carga negativa: " + e.getMessage());
         }
+
+        // Crear un camión con acoplado y mostrar sus datos
+        Camion camion = new Camion("TRK123", "Scania", 2022, 8000.0, true);
+        printer.imprimirInformacion(camion);
+        System.out.println("¿Tiene acoplado?: " + camion.tieneAcoplado());
+
     }
 }


### PR DESCRIPTION
Closes #7

Se creó la subclase `Camion` que extiende de `Vehiculo`, incorporando un nuevo atributo `tieneAcoplado` para representar si el camión posee o no un acoplado. 
Este cambio aplica correctamente el principio de abierto/cerrado (OCP), permitiendo extender la funcionalidad del sistema sin modificar las clases existentes.

Cambios realizados:

- Se creó la clase `Camion`, subclase de `Vehiculo`.
- Se agregó el atributo `tieneAcoplado` con getter y setter correspondientes.
- Se implementó un constructor que recibe todos los atributos de `Vehiculo` más `tieneAcoplado`.
- Se probó la clase `Camion` en `Main`, validando su correcta creación e integración con `VehiculoPrinter`.
- Se agregó documentación JavaDoc básica para la clase.

Con esta incorporación, el sistema permite representar un nuevo tipo de vehículo sin modificar la clase base `Vehiculo`, respetando el principio OCP y facilitando futuras extensiones como la impresión personalizada en `VehiculoPrinter`.
