### PR TITLE
refactor: aplicar OCP en VehiculoPrinter usando polimorfismo

### DIFF
--- a/src/Camion.java
+++ b/src/Camion.java
@@ -36,4 +36,21 @@ public class Camion extends Vehiculo {
     public void setTieneAcoplado(boolean tieneAcoplado) {
         this.tieneAcoplado = tieneAcoplado;
     }
+
+    /**
+     * Devuelve una representación en texto del camión, incluyendo los datos heredados
+     * y si tiene o no acoplado.
+     *
+     * @return Información detallada del camión.
+     */
+    @Override
+    public String toString() {
+        return "=== Información del Vehículo ===\n" +
+                "Patente: " + getPatente() + "\n" +
+                "Marca: " + getMarca() + "\n" +
+                "Año: " + getAnio() + "\n" +
+                "Capacidad de carga (kg): " + getCapacidadCargaKg() + "\n" +
+                "Tiene acoplado: " + (tieneAcoplado ? "Sí" : "No") + "\n" +
+                "===============================";
+    }
 }

--- a/src/Main.java
+++ b/src/Main.java
@@ -51,7 +51,9 @@ public class Main {
         // Crear un camión con acoplado y mostrar sus datos
         Camion camion = new Camion("TRK123", "Scania", 2022, 8000.0, true);
         printer.imprimirInformacion(camion);
-        System.out.println("¿Tiene acoplado?: " + camion.tieneAcoplado());
 
+        // Crear un camión sin acoplado y mostrar sus datos
+        Camion camionSinAcoplado = new Camion("TRK789", "Mercedes-Benz", 2021, 7500.0, false);
+        printer.imprimirInformacion(camionSinAcoplado);
     }
 }

--- a/src/Vehiculo.java
+++ b/src/Vehiculo.java
@@ -141,5 +141,18 @@ public class Vehiculo {
         }
     }
 
-
+    /**
+     * Devuelve una representación en texto del vehículo.
+     *
+     * @return Información detallada del vehículo.
+     */
+    @Override
+    public String toString() {
+        return "=== Información del Vehículo ===\n" +
+                "Patente: " + patente + "\n" +
+                "Marca: " + marca + "\n" +
+                "Año: " + anio + "\n" +
+                "Capacidad de carga (kg): " + capacidadCargaKg + "\n" +
+                "===============================";
+    }
 }

--- a/src/VehiculoPrinter.java
+++ b/src/VehiculoPrinter.java
@@ -7,9 +7,10 @@ public class VehiculoPrinter {
 
     /**
      * Imprime por consola los datos del vehículo proporcionado.
+     * Utiliza polimorfismo para imprimir subclases como Camion correctamente.
      * Si el parámetro es null, se muestra un mensaje de error.
      *
-     * @param vehiculo El objeto Vehiculo cuya información se desea mostrar.
+     * @param vehiculo El objeto Vehiculo (o subclase) cuya información se desea mostrar.
      */
     public void imprimirInformacion(Vehiculo vehiculo) {
         if (vehiculo == null) {
@@ -17,11 +18,6 @@ public class VehiculoPrinter {
             return;
         }
 
-        System.out.println("=== Información del Vehículo ===");
-        System.out.println("Patente: " + vehiculo.getPatente());
-        System.out.println("Marca: " + vehiculo.getMarca());
-        System.out.println("Año: " + vehiculo.getAnio());
-        System.out.println("Capacidad de carga (kg): " + vehiculo.getCapacidadCargaKg());
-        System.out.println("===============================");
+        System.out.println(vehiculo.toString());
     }
 }


### PR DESCRIPTION
Closes #8 

Se modificó la clase `VehiculoPrinter` para aplicar correctamente el principio de abierto/cerrado (OCP), permitiendo imprimir objetos de cualquier subclase de `Vehiculo` sin necesidad de modificar el código existente, utilizando polimorfismo.

Cambios realizados:

- Se agregó el método `toString()` en la clase `Vehiculo` para encapsular la representación del vehículo base.
- Se sobreescribió el método `toString()` en la subclase `Camion`, incluyendo el atributo `tieneAcoplado` en la salida.
- Se modificó la clase `VehiculoPrinter` para imprimir cualquier `Vehiculo` utilizando directamente el método `toString()`, evitando el uso de instanceof o condicionales.
- Se validó el funcionamiento correcto en la clase `Main`, imprimiendo tanto vehículos base como camiones.
- Se agregó documentación JavaDoc básica en las clases modificadas.

Con esta modificación, el sistema puede extenderse con nuevas subclases de `Vehiculo` sin necesidad de cambiar el código de impresión, cumpliendo con el principio OCP y mejorando la mantenibilidad del código.
